### PR TITLE
adds the ability to run calabash tests on android handsets concurrently

### DIFF
--- a/bin/parallel_calabash
+++ b/bin/parallel_calabash
@@ -37,6 +37,10 @@ def parse_arguments(arguments)
       options[:mute_output] = mute_output
     end
 
+    opts.on("--concurrent", "Run tests concurrently. Each test will run once on each device") do |concurrent_opt|
+      options[:concurrent] = true
+    end
+
   end
 
   opt_parser.parse!(arguments)

--- a/lib/parallel_calabash.rb
+++ b/lib/parallel_calabash.rb
@@ -26,10 +26,11 @@ module ParallelCalabash
 
       test_results = nil
       report_time_taken do
-        groups = FeatureGrouper.feature_groups(options[:feature_folder], number_of_processes,options[:distribution_tag])
-        puts "#{number_of_processes} processes for #{groups.flatten.size} features"
-        test_results = Parallel.map(groups, :in_threads => groups.size) do |group|
-          Runner.run_tests(group, groups.index(group), options)
+        groups = FeatureGrouper.feature_groups(options[:feature_folder], number_of_processes, options[:distribution_tag], options[:concurrent])
+        threads = groups.size
+
+        test_results = Parallel.map_with_index(groups, :in_threads => threads) do |group, index|
+          Runner.run_tests(group, index, options)
         end
         ResultFormatter.report_results(test_results)
       end

--- a/lib/parallel_calabash/feature_grouper.rb
+++ b/lib/parallel_calabash/feature_grouper.rb
@@ -3,8 +3,18 @@ module ParallelCalabash
 
     class << self
 
-      def feature_groups(feature_folder, group_size,weighing_factor = nil)
-        weighing_factor.nil? ? feature_groups_by_feature_files(feature_folder, group_size) :  feature_groups_by_weight(feature_folder, group_size,weighing_factor)
+      def feature_groups(feature_folder, group_size,weighing_factor = nil, concurrent = nil)
+        if concurrent.nil?
+          weighing_factor.nil? ? feature_groups_by_feature_files(feature_folder, group_size) :  feature_groups_by_weight(feature_folder, group_size,weighing_factor)
+        else
+          concurrent_feature_groups(feature_folder, group_size)
+        end
+      end
+
+      def concurrent_feature_groups(feature_folder, number_of_groups)
+        groups = []
+        (0...number_of_groups).each{ groups << feature_files_in_folder(feature_folder) }
+        groups
       end
 
       def feature_groups_by_feature_files(feature_folder, group_size)

--- a/spec/lib/parallel_calabash/feature_grouper_spec.rb
+++ b/spec/lib/parallel_calabash/feature_grouper_spec.rb
@@ -38,6 +38,17 @@ describe ParallelCalabash::FeatureGrouper do
       [["spec/test_data/features/aaa.feature", "spec/test_data/features/fff.feature"], ["spec/test_data/features/bbb.feature"], ["spec/test_data/features/ccc.feature"], ["spec/test_data/features/ddd.feature"], ["spec/test_data/features/eee.feature"]]
     end
 
+    it 'should create 1 group for concurrent 1 process' do
+      expect(ParallelCalabash::FeatureGrouper.feature_groups(['spec/test_data/features'], 1, nil, true)).to eq \
+      [["spec/test_data/features/aaa.feature", "spec/test_data/features/bbb.feature", "spec/test_data/features/ccc.feature", "spec/test_data/features/ddd.feature", "spec/test_data/features/eee.feature", "spec/test_data/features/fff.feature"]]
+    end
+
+    it 'should create 2 group for concurrent 2 processes' do
+      expect(ParallelCalabash::FeatureGrouper.feature_groups(['spec/test_data/features'], 2, nil, true)).to eq \
+      [["spec/test_data/features/aaa.feature", "spec/test_data/features/bbb.feature", "spec/test_data/features/ccc.feature", "spec/test_data/features/ddd.feature", "spec/test_data/features/eee.feature", "spec/test_data/features/fff.feature"],
+       ["spec/test_data/features/aaa.feature", "spec/test_data/features/bbb.feature", "spec/test_data/features/ccc.feature", "spec/test_data/features/ddd.feature", "spec/test_data/features/eee.feature", "spec/test_data/features/fff.feature"]]
+    end
+
   end
 
   describe :feature_weight do


### PR DESCRIPTION
using a --concurrent flag, will run tests concurrently.
eg, if there are 10 tests and 5 devices, all 10 tests will run on all 5 devices
so 50 tests will run
