### PR TITLE
adds the ability to process a cucumber rerun file

### DIFF
--- a/lib/parallel_calabash/feature_grouper.rb
+++ b/lib/parallel_calabash/feature_grouper.rb
@@ -54,6 +54,9 @@ module ParallelCalabash
         if File.directory?(feature_dir.first)
           files = Dir[File.join(feature_dir, "**{,/*/**}/*")].uniq
           files.grep(/\.feature$/)
+        elsif File.file?(feature_dir.first)
+          scenarios = File.open(feature_dir.first).collect{ |line| line.split(' ') }
+          scenarios.flatten
         end
       end
 

--- a/spec/lib/parallel_calabash/feature_grouper_spec.rb
+++ b/spec/lib/parallel_calabash/feature_grouper_spec.rb
@@ -9,6 +9,11 @@ describe ParallelCalabash::FeatureGrouper do
       expect(ParallelCalabash::FeatureGrouper.feature_files_in_folder ['spec/test_data/features']).to eq \
       ["spec/test_data/features/aaa.feature", "spec/test_data/features/bbb.feature", "spec/test_data/features/ccc.feature", "spec/test_data/features/ddd.feature", "spec/test_data/features/eee.feature", "spec/test_data/features/fff.feature"]
     end
+
+    it 'should find all the feature files in a rerun text file' do
+      expect(ParallelCalabash::FeatureGrouper.feature_files_in_folder ['spec/test_data/rerun.txt']).to eq \
+        ["features/aaa.feature:3", "features/aaa.feature:6", "features/aaa.feature:9", "features/bbb.feature:3", "features/bbb.feature:6", "features/bbb.feature:9"]
+    end
   end
 
   describe :feature_groups do

--- a/spec/test_data/rerun.txt
+++ b/spec/test_data/rerun.txt
@@ -1,0 +1,1 @@
+features/aaa.feature:3 features/aaa.feature:6 features/aaa.feature:9 features/bbb.feature:3 features/bbb.feature:6 features/bbb.feature:9


### PR DESCRIPTION
Cucumber can be instructed to output a list of any failed tests in a run.
It is then possible to run only those tests by specifying the file that
was written by cucumber and passing it into the next test run.
Cucumber already supports this ability natively, adding it as an option
to parallel_calabash wrapper
