### PR TITLE
updates adb helper to cope with no space after word device

### DIFF
--- a/lib/parallel_calabash/adb_helper.rb
+++ b/lib/parallel_calabash/adb_helper.rb
@@ -19,7 +19,7 @@ module ParallelCalabash
       end
 
       def device_id_and_model line
-        if line.include?("device ")
+        if line.match(/device(?!s)/)
           [line.split(" ").first,line.scan(/model:(.*) device/).flatten.first]
         end
       end

--- a/spec/lib/parallel_calabash/adb_helper_spec.rb
+++ b/spec/lib/parallel_calabash/adb_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+require 'parallel_calabash/adb_helper'
+describe ParallelCalabash::AdbHelper do
+
+  describe :device_id_and_model do
+    it 'should not match any devices in list of devices attached line' do
+      expect(ParallelCalabash::AdbHelper.device_id_and_model("List of devices attached")).to eq nil
+    end
+
+    it 'should match devices if there is a space after the word device' do
+       expect(ParallelCalabash::AdbHelper.device_id_and_model("emulator-5554  device ")).to eq \
+         ["emulator-5554", nil]
+    end
+
+    it 'should match devices if there is not a space after the word device' do
+      expect(ParallelCalabash::AdbHelper.device_id_and_model("emulator-5554  device")).to eq \
+         ["emulator-5554", nil]
+    end
+
+    it 'should not match a device if it is an empty line' do
+      expect(ParallelCalabash::AdbHelper.device_id_and_model("")).to eq nil
+    end
+
+    it 'should match physical devices' do
+      output = "192.168.56.101:5555 device product:vbox86p model:device1 device:vbox86p"
+      expect(ParallelCalabash::AdbHelper.device_id_and_model(output)).to eq ["192.168.56.101:5555", "device1"]
+    end
+  end
+end


### PR DESCRIPTION
adb seems to have changed its output from
"emulator-5554     device " to
"emulator-5554     device"
note the space after the work device

change uses a regular expression to match the word device with or
without a space after it, but does not match the word devices
