### PR TITLE
adds ability to filter which devices tests are run against

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,22 @@ Example: parallel_calabash -a my.apk -o 'cucumber_opts_like_tags_profile_etc_her
     -v, --version                    Show version
     -a, --apk apk_path               apk file path
     -o, --cucumber_opts '[OPTIONS]'  execute with those cucumber options
+    -f, --filter                     Filter devices to run tests against using partial device id or model name matching. Multiple filters seperated by ','
     --serialize-stdout               Serialize stdout output, nothing will be written until everything is done
     --group-by-scenarios             Distribute equally as per scenarios. This uses cucumber dry run
     --concurrent                     Run tests concurrently. Each test will run once on each device.
+
+
+## FILTERING
+Filters are partial matches on the device id, or model name.
+> adb devices -l
+List of devices attached
+4100142545f271b5       device usb:14200000 product:sltexx model:SM_G850F device:slte
+4366432135f271c6       device usb:14200000 product:sltexx model:SM_G9901 device:slte
+emulator-5554          device product:sdk_phone_x86_64 model:Android_SDK_built_for_x86_64 device:generic_x86_64
+
+To run against just the emulator: -f emulator
+To run against a device id list: -f 4100142545f271b5,4366432135f271c6
 
 ## REPROTING
 

--- a/bin/parallel_calabash
+++ b/bin/parallel_calabash
@@ -29,6 +29,10 @@ def parse_arguments(arguments)
       options[:distribution_tag] = distribution_tag
     end
 
+    opts.on("-f", "--filter filter", "Filter devices to run tests against using partial device id or model name matching. Multiple filters seperated by ','") do |filter_opts|
+      options[:filter] = filter_opts.split(",")
+    end
+
     opts.on("-o", "--cucumber_opts '[OPTIONS]'", "execute with those cucumber options") do |cucumber_opts|
       options[:cucumber_options] = cucumber_opts
     end

--- a/lib/parallel_calabash.rb
+++ b/lib/parallel_calabash.rb
@@ -12,8 +12,8 @@ module ParallelCalabash
   WINDOWS = (RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   class << self
 
-    def number_of_processes_to_start
-      number_of_processes = AdbHelper.number_of_connected_devices
+    def number_of_processes_to_start options
+      number_of_processes = AdbHelper.number_of_connected_devices(options[:filter])
       raise "\n**** NO DEVICE FOUND ****\n" if number_of_processes==0
       puts "*******************************"
       puts " #{number_of_processes} DEVICES FOUND"
@@ -22,7 +22,7 @@ module ParallelCalabash
     end
 
     def run_tests_in_parallel(options)
-      number_of_processes = number_of_processes_to_start
+      number_of_processes = number_of_processes_to_start(options)
 
       test_results = nil
       report_time_taken do

--- a/lib/parallel_calabash/adb_helper.rb
+++ b/lib/parallel_calabash/adb_helper.rb
@@ -2,17 +2,22 @@ module ParallelCalabash
   module AdbHelper
     class << self
 
-      def device_for_process process_num
-        connected_devices_with_model_info[process_num]
+      def device_for_process process_num, filter=[]
+        connected_devices_with_model_info(filter)[process_num]
       end
 
-      def number_of_connected_devices
-        connected_devices_with_model_info.size
+      def number_of_connected_devices filter=[]
+        connected_devices_with_model_info(filter).size
       end
 
-      def connected_devices_with_model_info
+      def connected_devices_with_model_info filter
         begin
-          `adb devices -l`.split("\n").collect{|line|  device_id_and_model(line)}.compact
+          list =
+            `adb devices -l`.split("\n").collect do |line|
+              device = device_id_and_model(line)
+              filter_device(device, filter)
+            end
+          list.compact
         rescue
           []
         end
@@ -21,6 +26,14 @@ module ParallelCalabash
       def device_id_and_model line
         if line.include?("device ")
           [line.split(" ").first,line.scan(/model:(.*) device/).flatten.first]
+        end
+      end
+
+      def filter_device device, filter
+        if filter && !filter.empty? && device
+          device unless filter.collect{|f| device[0].match(f) || device[1].match(f) }.compact.empty?
+        else
+          device
         end
       end
 

--- a/lib/parallel_calabash/runner.rb
+++ b/lib/parallel_calabash/runner.rb
@@ -7,11 +7,11 @@ module ParallelCalabash
 
       def run_tests(test_files, process_number, options)
         cmd = [base_command, options[:apk_path], options[:cucumber_options], *test_files].compact*' '
-        execute_command_for_process(process_number, cmd, options[:mute_output])
+        execute_command_for_process(process_number, cmd, options[:mute_output], options[:filter])
       end
 
-      def execute_command_for_process(process_number, cmd, silence)
-        command_for_current_process = command_for_process(process_number, cmd)
+      def execute_command_for_process(process_number, cmd, silence, filter)
+        command_for_current_process = command_for_process(process_number, cmd, filter)
         output = open("|#{command_for_current_process}", "r") { |output| show_output(output, silence) }
         exitstatus = $?.exitstatus
 
@@ -23,9 +23,9 @@ module ParallelCalabash
         {:stdout => output, :exit_status => exitstatus}
       end
 
-      def command_for_process process_number, cmd
+      def command_for_process(process_number, cmd, filter)
         env = {}
-        device_id, device_info = ParallelCalabash::AdbHelper.device_for_process process_number
+        device_id, device_info = ParallelCalabash::AdbHelper.device_for_process process_number, filter
         env = env.merge({'AUTOTEST' => '1', 'ADB_DEVICE_ARG' => device_id, 'DEVICE_INFO' => device_info, "TEST_PROCESS_NUMBER" => (process_number+1).to_s})
         separator = (WINDOWS ? ' & ' : ';')
         exports = env.map { |k, v| WINDOWS ? "(SET \"#{k}=#{v}\")" : "#{k}=#{v};export #{k}" }.join(separator)

--- a/spec/lib/parallel_calabash/adb_helper_spec.rb
+++ b/spec/lib/parallel_calabash/adb_helper_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+require 'parallel_calabash/adb_helper'
+describe ParallelCalabash::AdbHelper do
+
+  describe :filter_device do
+    it 'should return devices if no filter is specified' do
+      device = ["192.168.56.101:5555", "device1"]
+      expect(ParallelCalabash::AdbHelper.filter_device(device, [])).to eq device
+    end
+
+    it 'should match devices that match the filter' do
+      device = ["192.168.56.101:5555", "device1"]
+      expect(ParallelCalabash::AdbHelper.filter_device(device, ["device1"])).to eq device
+    end
+
+    it 'should not return devices that do not match the filter' do
+      device = ["192.168.56.101:5555", "device1"]
+      expect(ParallelCalabash::AdbHelper.filter_device(device, ["notmatching"])).to eq nil
+    end
+
+    it 'can also match on ip address' do
+      device = ["192.168.56.101:5555", "device1"]
+      expect(ParallelCalabash::AdbHelper.filter_device(device, ["192.168.56.101"])).to eq device
+    end
+  end
+
+end

--- a/spec/lib/parallel_calabash/runner_spec.rb
+++ b/spec/lib/parallel_calabash/runner_spec.rb
@@ -4,8 +4,8 @@ require 'parallel_calabash'
 describe ParallelCalabash::Runner do
   describe :command_for_process do
     it 'should return command with env variables' do
-      ParallelCalabash::AdbHelper.should_receive(:device_for_process).with(0).and_return(["4d00fa3cb814c03f", "GT_N7100"])
-      expect(ParallelCalabash::Runner.command_for_process(0, 'base_command')).to eq \
+      ParallelCalabash::AdbHelper.should_receive(:device_for_process).with(0,nil).and_return(["4d00fa3cb814c03f", "GT_N7100"])
+      expect(ParallelCalabash::Runner.command_for_process(0, 'base_command', nil)).to eq \
       "AUTOTEST=1;export AUTOTEST;ADB_DEVICE_ARG=4d00fa3cb814c03f;export ADB_DEVICE_ARG;DEVICE_INFO=GT_N7100;export DEVICE_INFO;TEST_PROCESS_NUMBER=1;export TEST_PROCESS_NUMBER;base_command"
     end
   end
@@ -13,12 +13,12 @@ describe ParallelCalabash::Runner do
 
   describe :execute_command_for_process do
     it 'should execute the command with correct env variables set and return exit status 0 when command gets executed successfully' do
-      ParallelCalabash::AdbHelper.should_receive(:device_for_process).with(3).and_return("DEVICE3")
-      expect(ParallelCalabash::Runner.execute_command_for_process(3,'echo $ADB_DEVICE_ARG;echo $TEST_PROCESS_NUMBER',true)).to eq ({:stdout=>"DEVICE3\n4\n", :exit_status=>0})
+      ParallelCalabash::AdbHelper.should_receive(:device_for_process).with(3,nil).and_return("DEVICE3")
+      expect(ParallelCalabash::Runner.execute_command_for_process(3,'echo $ADB_DEVICE_ARG;echo $TEST_PROCESS_NUMBER',true,nil)).to eq ({:stdout=>"DEVICE3\n4\n", :exit_status=>0})
     end
 
     it 'should return exit status of 1' do
-      expect(ParallelCalabash::Runner.execute_command_for_process(3,"ruby -e 'exit(1)'",true)).to eq ({:stdout=>"", :exit_status=>1})
+      expect(ParallelCalabash::Runner.execute_command_for_process(3,"ruby -e 'exit(1)'",true,nil)).to eq ({:stdout=>"", :exit_status=>1})
     end
   end
 


### PR DESCRIPTION
using the -f option, does a partial match on device id or model name
can specify multiple matches by seperating with a ','
eg: -f emualtor,9847292
- run on all emulators, and devices that have 9847292 in their id
