### PR TITLE
Clearly report incorrect argument(s) and terminate with help message

### DIFF
--- a/bin/parallel_calabash
+++ b/bin/parallel_calabash
@@ -54,9 +54,9 @@ def parse_arguments(arguments)
   opt_parser.parse!(arguments)
   options[:feature_folder] = arguments
   options
-rescue OptionParser::InvalidOption
-  puts "Invalid arguments "
-  puts opt_parser.help
+rescue OptionParser::InvalidOption => e
+  puts "Invalid arguments #{e}"
+  fail opt_parser.help
 end
 
 options = parse_arguments(ARGV)


### PR DESCRIPTION
I found this helpful: to be told what was wrong with my flags, and for the tests to stop immediately.
